### PR TITLE
Add custom error message to custom error handler

### DIFF
--- a/src/expected-error-handler.js
+++ b/src/expected-error-handler.js
@@ -13,13 +13,14 @@ const logger = createLogger('express-middleware')
 
 const errorRegistry = new Map()
 
-const registerError = (errorClass, httpStatusCode) => {
+const registerError = (errorClass, httpStatusCode, httpResponseMsg) => {
   if (errorRegistry.has(errorClass.name)) {
     throw new Error(`Missconfiguration, an error with name '${errorClass.name}' is already registered`)
   }
   errorRegistry.set(errorClass.name, {
     errorClass,
     httpStatusCode,
+    httpResponseMsg,
   })
 }
 
@@ -43,10 +44,9 @@ const expectedErrorHandler = (err, req, res, next) => {
     if (err instanceof errorEntry.errorClass) {
       logger.debug({ err }, `handled expected error: ${err.name}`)
 
-      res.status(errorEntry.httpStatusCode).json({
-        name: err.name,
-        message: err.message,
-      })
+      const { name } = err
+      const message = errorEntry.httpResponseMsg || err.message
+      res.status(errorEntry.httpStatusCode).json({ name, message })
 
       next()
       return

--- a/test/expected-error-handler.test.js
+++ b/test/expected-error-handler.test.js
@@ -116,19 +116,19 @@ describe('expected-error-handler', () => {
       })
     })
     it('should send custom http msg on CustomError', async () => {
-      class CustomError extends Error {}
-      CustomError.prototype.name = CustomError.name
-      registerError(CustomError, 442, 'custom message')
+      class CustomErrorWithDifferentMsg extends Error {}
+      CustomErrorWithDifferentMsg.prototype.name = CustomErrorWithDifferentMsg.name
+      registerError(CustomErrorWithDifferentMsg, 442, 'custom message')
 
       runServer(async () => {
-        throw new CustomError('custom error')
+        throw new CustomErrorWithDifferentMsg('custom error')
       })
 
       const { port } = server.address()
       const response = await request(`http://localhost:${port}`).get('/some-route')
       expect(response.body).to.deep.equal({
         message: 'custom message',
-        name: 'CustomError',
+        name: 'CustomErrorWithDifferentMsg',
       })
     })
   })

--- a/test/expected-error-handler.test.js
+++ b/test/expected-error-handler.test.js
@@ -131,6 +131,24 @@ describe('expected-error-handler', () => {
         name: 'CustomErrorWithDifferentMsg',
       })
     })
+    it('should send custom http msg on CustomError when passed as option', async () => {
+      class CustomErrorForOptionTest extends Error {}
+      CustomErrorForOptionTest.prototype.name = CustomErrorForOptionTest.name
+      registerError(CustomErrorForOptionTest, 442, {
+        httpResponseMsg: 'custom message',
+      })
+
+      runServer(async () => {
+        throw new CustomErrorForOptionTest('custom error')
+      })
+
+      const { port } = server.address()
+      const response = await request(`http://localhost:${port}`).get('/some-route')
+      expect(response.body).to.deep.equal({
+        message: 'custom message',
+        name: 'CustomErrorForOptionTest',
+      })
+    })
   })
 
   describe('misconfiguration', () => {

--- a/test/expected-error-handler.test.js
+++ b/test/expected-error-handler.test.js
@@ -115,6 +115,21 @@ describe('expected-error-handler', () => {
         message: 'custom error',
       })
     })
+    it('should send custom http msg on CustomError', async () => {
+      class CustomError extends Error {}
+      CustomError.prototype.name = CustomError.name
+      registerError(CustomError, 442, 'custom message')
+
+      runServer(async () => {
+        throw new CustomError('custom error')
+      })
+
+      const { port } = server.address()
+      const response = await request(`http://localhost:${port}`).get('/some-route')
+      expect(response.body).to.deep.equal({
+        message: 'custom message',
+      })
+    })
   })
 
   describe('misconfiguration', () => {

--- a/test/expected-error-handler.test.js
+++ b/test/expected-error-handler.test.js
@@ -128,6 +128,7 @@ describe('expected-error-handler', () => {
       const response = await request(`http://localhost:${port}`).get('/some-route')
       expect(response.body).to.deep.equal({
         message: 'custom message',
+        name: 'CustomError',
       })
     })
   })


### PR DESCRIPTION
This pull requests provides the possibility to register custom errors along with a custom message. 

## Motivation
As a user of this library I want to have the possibility to register Errors of external libraries but provide a custom message. This releases me from catching certain errors and just wrapping them into local errors.

## Example
```
-------- ./service/bar-service.js
import { ExternalError, externalService } from 'external-lib'

registerError(ExternalError, 503, 'Connection to foo is not available')

function doServiceStuff() {
    externalService()
}
```

## Workaround using additional local express error handlers ("composition approach")
This workaround provides the same result but has two fallbacks:
* a lot more boilerplate code
* service local external errors force me to change my middleware implementations

```
-------- ./service/bar-service.js
import { externalService } from 'external-lib'

function doServiceStuff() {
    externalService()
}
-------- ./server.js
import { ExternalError } from 'external-lib'

class CustomExternalError extends Error {
   constructor(err) {
         super(err)
         this.message = 'Connection to foo is not available'
    }
}
registerError(CustomExternalError, 503)

app.use((err, req, res, next) => {
    if (err instanceof ExternalError) next(new CustomExternalError(err))
    else next(err)
})
app.use(expectedErrorHandler)
```